### PR TITLE
Added unwrapping of paramrefs and remarks when extracting XML Docs.

### DIFF
--- a/Generator/XMLDocsFetcher.cs
+++ b/Generator/XMLDocsFetcher.cs
@@ -32,6 +32,21 @@ public static class XMLDocsFetcher
         {
             seeReference.OuterHtml = seeReference.GetAttribute("cref")?.Split(".").Last() ?? seeReference.GetAttribute("langword")?.Split(".").Last() ?? string.Empty;
         }
+        foreach (var paramReference in document.QuerySelectorAll("paramref"))
+        {
+            if (paramReference.GetAttribute("name") is { } paramName)
+            {
+                paramReference.OuterHtml = paramName;
+            }
+            else
+            {
+                paramReference.OuterHtml = string.Empty;
+            }
+        }
+        foreach (var remarks in document.QuerySelectorAll("remarks"))
+        {
+            remarks.OuterHtml = remarks.InnerHtml;
+        }
 
         foreach (var member in document.GetElementsByTagName("doc")[0].Children[1].Children)
         {

--- a/src/Models/ProductQuery.php
+++ b/src/Models/ProductQuery.php
@@ -16,9 +16,9 @@ class ProductQuery extends LicensedRequest
     public bool $includeDisabledProducts;
     public bool $includeDisabledVariants;
     public bool $excludeProductsWithNoVariants;
-    /** The identifier for the ProductQuery paged cursor, to consume results in PageSize batches. Leave as null for retrieving the first page, and set to the value returned in NextPageToken for any subsequent page requests. <remarks>Should a wrong/unexisting token be supplied, a 'Validation' exception shall be returned.</remarks> */
+    /** The identifier for the ProductQuery paged cursor, to consume results in PageSize batches. Leave as null for retrieving the first page, and set to the value returned in NextPageToken for any subsequent page requests. Should a wrong/unexisting token be supplied, a 'Validation' exception shall be returned. */
     public ?string $nextPageToken;
-    /** The size of the page requested. <remarks>Maximum allowed value is 1000.</remarks> */
+    /** The size of the page requested. Maximum allowed value is 1000. */
     public ?int $pageSize;
     /** Settings for which properties should be included for the entities in the response. If settings are not set they default to include everything. */
     public ?ProductQuerySelectedPropertiesSettings $resultSettings;
@@ -141,14 +141,14 @@ class ProductQuery extends LicensedRequest
         return $this;
     }
     
-    /** The identifier for the ProductQuery paged cursor, to consume results in PageSize batches. Leave as null for retrieving the first page, and set to the value returned in NextPageToken for any subsequent page requests. <remarks>Should a wrong/unexisting token be supplied, a 'Validation' exception shall be returned.</remarks> */
+    /** The identifier for the ProductQuery paged cursor, to consume results in PageSize batches. Leave as null for retrieving the first page, and set to the value returned in NextPageToken for any subsequent page requests. Should a wrong/unexisting token be supplied, a 'Validation' exception shall be returned. */
     function setNextPageToken(?string $nextPageToken)
     {
         $this->nextPageToken = $nextPageToken;
         return $this;
     }
     
-    /** The size of the page requested. <remarks>Maximum allowed value is 1000.</remarks> */
+    /** The size of the page requested. Maximum allowed value is 1000. */
     function setPageSize(?int $pageSize)
     {
         $this->pageSize = $pageSize;


### PR DESCRIPTION
Related to: https://trello.com/c/lMT5fsTv/12051-sdk-php-sdk-support-unwrapping-remarks-and-using-paramrefs-in-php-doc

We implemented this for Java last year, and now we have also implemented it for PHP. It was basically copy-paste.

In Java, we create more constructors/creator methods because it supports method overloading. So in the PHP case, we didn't see any parameter references, as those constructors were not included. But now we have it for the future, once more begin to use paramrefs.

But it did catch a couple of `remarks` tags. :)