### PR TITLE
Add batching logic to generated PHP clients

### DIFF
--- a/Generator/PhpClientWriter.cs
+++ b/Generator/PhpClientWriter.cs
@@ -41,14 +41,16 @@ public class PhpClientWriter
                     .Where(derivingType => !derivingType.IsGenericType && derivingType.IsAssignableTo(info.GetParameters().First().ParameterType))
                     .Select(derivedType => (
                         methodName: phpWriter.PhpTypeName(derivedType).ToCamelCase(),
-                        parameterType: phpWriter.PhpTypeName(derivedType),
+                        parameterTypeName: phpWriter.PhpTypeName(derivedType),
+                        parameterClrType: derivedType,
                         parameterName: info.GetParameters().First().Name!,
                         returnType: info.ReturnType))
                 : new[]
                 {
                 (
                     methodName: phpWriter.PhpTypeName(info.GetParameters().First().ParameterType).ToCamelCase(),
-                    parameterType: phpWriter.PhpTypeName(info.GetParameters().First().ParameterType),
+                    parameterTypeName: phpWriter.PhpTypeName(info.GetParameters().First().ParameterType),
+                    parameterClrType: info.GetParameters().First().ParameterType,
                     parameterName: info.GetParameters().First().Name!,
                     returnType: info.ReturnType)
                 })
@@ -62,9 +64,9 @@ namespace Relewise;
 use Relewise\Infrastructure\HttpClient\Response;
 """);
 
-        foreach (var method in clientMethods.DistinctBy(method => method.parameterType))
+        foreach (var method in clientMethods.DistinctBy(method => method.parameterTypeName))
         {
-            writer.WriteLine($"use {Constants.Namespace}\\{method.parameterType};");
+            writer.WriteLine($"use {Constants.Namespace}\\{method.parameterTypeName};");
         }
         foreach (var method in clientMethods.DistinctBy(method => method.returnType).Where(method => method.returnType != typeof(void)))
         {
@@ -83,28 +85,120 @@ use Relewise\Infrastructure\HttpClient\Response;
         writer.Indent--;
         writer.WriteLine("}");
 
-        foreach (var method in clientMethods.DistinctBy(method => method.parameterType))
+        foreach (var method in clientMethods.DistinctBy(method => method.parameterTypeName))
         {
             var methodName = method.methodName.EndsWith("Request") ? method.methodName[..^7].ToCamelCase() : method.methodName.EndsWith("RequestCollection") ? $"batch{method.methodName[..^17]}" : method.methodName.ToCamelCase();
 
             writer.WriteLine();
-            writer.WriteLine($"public function {methodName}({method.parameterType} ${method.parameterName}){(method.returnType != typeof(void) ? $" : ?{phpWriter.PhpTypeName(method.returnType)}" : "")}");
+            writer.WriteLine($"public function {methodName}({method.parameterTypeName} ${method.parameterName}){(method.returnType != typeof(void) ? $" : ?{phpWriter.PhpTypeName(method.returnType)}" : "")}");
             writer.WriteLine("{");
             writer.Indent++;
-            if (method.returnType == typeof(void))
+            var collectionProperty = method.parameterClrType.GetProperty("Requests")?.Name
+                ?? method.parameterClrType.GetProperty("Items")?.Name;
+            var phpCollectionProperty = collectionProperty?.ToCamelCase();
+
+            if (phpCollectionProperty is not null)
             {
-                writer.WriteLine($"return $this->requestAndValidate(\"{method.parameterType}\", ${method.parameterName});");
+                if (method.returnType == typeof(void))
+                {
+                    writer.WriteLine($"if (!isset(${method.parameterName}->{phpCollectionProperty}) || count(${method.parameterName}->{phpCollectionProperty}) === 0)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine("return;");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine($"$chunks = count(${method.parameterName}->{phpCollectionProperty}) > $this->batchSize");
+                    writer.WriteLine("    ? array_chunk(${method.parameterName}->{phpCollectionProperty}, $this->batchSize)");
+                    writer.WriteLine($"    : array(${method.parameterName}->{phpCollectionProperty});");
+                    writer.WriteLine("foreach ($chunks as $chunk)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine($"$chunkedRequest = clone ${method.parameterName};");
+                    writer.WriteLine($"$chunkedRequest->{phpCollectionProperty} = $chunk;");
+                    writer.WriteLine($"$this->requestAndValidate(\"{method.parameterTypeName}\", $chunkedRequest);");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine("return;");
+                }
+                else
+                {
+                    var responseCollectionProperty = method.returnType.GetProperty("Responses")?.Name?.ToCamelCase();
+                    writer.WriteLine($"if (!isset(${method.parameterName}->{phpCollectionProperty}) || count(${method.parameterName}->{phpCollectionProperty}) === 0)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine("return Null;");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine($"$chunks = count(${method.parameterName}->{phpCollectionProperty}) > $this->batchSize");
+                    writer.WriteLine("    ? array_chunk(${method.parameterName}->{phpCollectionProperty}, $this->batchSize)");
+                    writer.WriteLine($"    : array(${method.parameterName}->{phpCollectionProperty});");
+                    writer.WriteLine("$aggregatedResponse = Null;");
+                    writer.WriteLine("foreach ($chunks as $chunk)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine($"$chunkedRequest = clone ${method.parameterName};");
+                    writer.WriteLine($"$chunkedRequest->{phpCollectionProperty} = $chunk;");
+                    writer.WriteLine($"$chunkResponse = $this->requestAndValidate(\"{method.parameterTypeName}\", $chunkedRequest);");
+                    writer.WriteLine("if ($chunkResponse == Null)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine("continue;");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine($"$hydratedChunkResponse = {phpWriter.PhpTypeName(method.returnType)}::hydrate($chunkResponse);");
+                    writer.WriteLine("if ($aggregatedResponse == Null)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine("$aggregatedResponse = $hydratedChunkResponse;");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine("else");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    if (responseCollectionProperty is not null)
+                    {
+                        writer.WriteLine($"if (isset($hydratedChunkResponse->{responseCollectionProperty}))");
+                        writer.WriteLine("{");
+                        writer.Indent++;
+                        writer.WriteLine($"if (!isset($aggregatedResponse->{responseCollectionProperty}))");
+                        writer.WriteLine("{");
+                        writer.Indent++;
+                        writer.WriteLine($"$aggregatedResponse->{responseCollectionProperty} = array();");
+                        writer.Indent--;
+                        writer.WriteLine("}");
+                        writer.WriteLine($"$aggregatedResponse->{responseCollectionProperty} = array_merge(");
+                        writer.Indent++;
+                        writer.WriteLine($"$aggregatedResponse->{responseCollectionProperty},");
+                        writer.WriteLine($"$hydratedChunkResponse->{responseCollectionProperty}");
+                        writer.Indent--;
+                        writer.WriteLine(");");
+                        writer.Indent--;
+                        writer.WriteLine("}");
+                    }
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine("return $aggregatedResponse;");
+                }
             }
             else
             {
-                writer.WriteLine($"$response = $this->requestAndValidate(\"{method.parameterType}\", ${method.parameterName});");
-                writer.WriteLine("if ($response == Null)");
-                writer.WriteLine("{");
-                writer.Indent++;
-                writer.WriteLine("return Null;");
-                writer.Indent--;
-                writer.WriteLine("}");
-                writer.WriteLine($"return {phpWriter.PhpTypeName(method.returnType)}::hydrate($response);");
+                if (method.returnType == typeof(void))
+                {
+                    writer.WriteLine($"return $this->requestAndValidate(\"{method.parameterTypeName}\", ${method.parameterName});");
+                }
+                else
+                {
+                    writer.WriteLine($"$response = $this->requestAndValidate(\"{method.parameterTypeName}\", ${method.parameterName});");
+                    writer.WriteLine("if ($response == Null)");
+                    writer.WriteLine("{");
+                    writer.Indent++;
+                    writer.WriteLine("return Null;");
+                    writer.Indent--;
+                    writer.WriteLine("}");
+                    writer.WriteLine($"return {phpWriter.PhpTypeName(method.returnType)}::hydrate($response);");
+                }
             }
             writer.Indent--;
             writer.WriteLine("}");

--- a/src/Recommender.php
+++ b/src/Recommender.php
@@ -324,22 +324,86 @@ class Recommender extends RelewiseClient
     
     public function batchproductRecommendation(ProductRecommendationRequestCollection $request) : ?ProductRecommendationResponseCollection
     {
-        $response = $this->requestAndValidate("ProductRecommendationRequestCollection", $request);
-        if ($response == Null)
+        if (!isset($request->requests) || count($request->requests) === 0)
         {
             return Null;
         }
-        return ProductRecommendationResponseCollection::hydrate($response);
+        $chunks = count($request->requests) > $this->batchSize
+            ? array_chunk($request->requests, $this->batchSize)
+            : array($request->requests);
+        $aggregatedResponse = Null;
+        foreach ($chunks as $chunk)
+        {
+            $chunkedRequest = clone $request;
+            $chunkedRequest->requests = $chunk;
+            $chunkResponse = $this->requestAndValidate("ProductRecommendationRequestCollection", $chunkedRequest);
+            if ($chunkResponse == Null)
+            {
+                continue;
+            }
+            $hydratedChunkResponse = ProductRecommendationResponseCollection::hydrate($chunkResponse);
+            if ($aggregatedResponse == Null)
+            {
+                $aggregatedResponse = $hydratedChunkResponse;
+            }
+            else
+            {
+                if (isset($hydratedChunkResponse->responses))
+                {
+                    if (!isset($aggregatedResponse->responses))
+                    {
+                        $aggregatedResponse->responses = array();
+                    }
+                    $aggregatedResponse->responses = array_merge(
+                        $aggregatedResponse->responses,
+                        $hydratedChunkResponse->responses
+                    );
+                }
+            }
+        }
+        return $aggregatedResponse;
     }
-    
+
     public function batchcontentRecommendation(ContentRecommendationRequestCollection $request) : ?ContentRecommendationResponseCollection
     {
-        $response = $this->requestAndValidate("ContentRecommendationRequestCollection", $request);
-        if ($response == Null)
+        if (!isset($request->requests) || count($request->requests) === 0)
         {
             return Null;
         }
-        return ContentRecommendationResponseCollection::hydrate($response);
+        $chunks = count($request->requests) > $this->batchSize
+            ? array_chunk($request->requests, $this->batchSize)
+            : array($request->requests);
+        $aggregatedResponse = Null;
+        foreach ($chunks as $chunk)
+        {
+            $chunkedRequest = clone $request;
+            $chunkedRequest->requests = $chunk;
+            $chunkResponse = $this->requestAndValidate("ContentRecommendationRequestCollection", $chunkedRequest);
+            if ($chunkResponse == Null)
+            {
+                continue;
+            }
+            $hydratedChunkResponse = ContentRecommendationResponseCollection::hydrate($chunkResponse);
+            if ($aggregatedResponse == Null)
+            {
+                $aggregatedResponse = $hydratedChunkResponse;
+            }
+            else
+            {
+                if (isset($hydratedChunkResponse->responses))
+                {
+                    if (!isset($aggregatedResponse->responses))
+                    {
+                        $aggregatedResponse->responses = array();
+                    }
+                    $aggregatedResponse->responses = array_merge(
+                        $aggregatedResponse->responses,
+                        $hydratedChunkResponse->responses
+                    );
+                }
+            }
+        }
+        return $aggregatedResponse;
     }
     
     public function productRecommendation(ProductRecommendationRequest $request) : ?ProductRecommendationResponse

--- a/src/RelewiseClient.php
+++ b/src/RelewiseClient.php
@@ -23,6 +23,7 @@ abstract class RelewiseClient
     private string $clientName = "RelewisePHPClient";
     private string $clientVersion;
     private Client $client;
+    protected int $batchSize = 100;
 
     public function __construct(private string $datasetId, private string $apiKey, private int $timeout)
     {
@@ -32,6 +33,20 @@ abstract class RelewiseClient
         }
         $this->clientVersion = \Composer\InstalledVersions::getRootPackage()["version"];
         $this->client = new CurlClient();
+    }
+
+    public function setBatchSize(int $batchSize)
+    {
+        if ($batchSize < 1)
+        {
+            throw new InvalidArgumentException("batchSize must be greater than 0.");
+        }
+        $this->batchSize = $batchSize;
+    }
+
+    public function getBatchSize(): int
+    {
+        return $this->batchSize;
     }
 
     public function request(string $endpoint, LicensedRequest $request): Response

--- a/src/Tracker.php
+++ b/src/Tracker.php
@@ -36,7 +36,20 @@ class Tracker extends RelewiseClient
     
     public function batchedTracking(BatchedTrackingRequest $trackingRequest)
     {
-        return $this->requestAndValidate("BatchedTrackingRequest", $trackingRequest);
+        if (!isset($trackingRequest->items) || count($trackingRequest->items) === 0)
+        {
+            return;
+        }
+        $chunks = count($trackingRequest->items) > $this->batchSize
+            ? array_chunk($trackingRequest->items, $this->batchSize)
+            : array($trackingRequest->items);
+        foreach ($chunks as $chunk)
+        {
+            $chunkedRequest = clone $trackingRequest;
+            $chunkedRequest->items = $chunk;
+            $this->requestAndValidate("BatchedTrackingRequest", $chunkedRequest);
+        }
+        return;
     }
     
     public function trackBrandAdministrativeAction(TrackBrandAdministrativeActionRequest $trackingRequest)

--- a/tests/php/unit/BatchingTest.php
+++ b/tests/php/unit/BatchingTest.php
@@ -1,0 +1,222 @@
+<?php declare(strict_types=1);
+
+namespace Relewise\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Relewise\Recommender;
+use Relewise\Searcher;
+use Relewise\Tracker;
+use Relewise\Models\BatchedTrackingRequest;
+use Relewise\Models\LicensedRequest;
+use Relewise\Models\ProductRecommendationRequest;
+use Relewise\Models\ProductRecommendationRequestCollection;
+use Relewise\Models\ProductRecommendationResponseCollection;
+use Relewise\Models\SearchRequest;
+use Relewise\Models\SearchRequestCollection;
+use Relewise\Models\SearchResponseCollection;
+use Relewise\Models\Trackable;
+
+class BatchingTest extends TestCase
+{
+    public function testTrackerBatchedTrackingSplitsItemsIntoChunks(): void
+    {
+        $tracker = new class('dataset-id', 'api-key') extends Tracker {
+            public array $calls = [];
+
+            public function requestAndValidate(string $endpoint, LicensedRequest $request)
+            {
+                $this->calls[] = ['endpoint' => $endpoint, 'request' => $request];
+                return null;
+            }
+        };
+
+        $tracker->setBatchSize(2);
+
+        $items = [
+            $this->createTrackable(1),
+            $this->createTrackable(2),
+            $this->createTrackable(3),
+            $this->createTrackable(4),
+            $this->createTrackable(5),
+        ];
+
+        $request = new BatchedTrackingRequest();
+        $request->items = $items;
+
+        $tracker->batchedTracking($request);
+
+        self::assertCount(3, $tracker->calls);
+        self::assertSame('BatchedTrackingRequest', $tracker->calls[0]['endpoint']);
+        self::assertSame('BatchedTrackingRequest', $tracker->calls[1]['endpoint']);
+        self::assertSame('BatchedTrackingRequest', $tracker->calls[2]['endpoint']);
+
+        self::assertNotSame($request, $tracker->calls[0]['request']);
+        self::assertSame([1, 2], array_map(fn (Trackable $item) => $item->id, $tracker->calls[0]['request']->items));
+        self::assertSame([3, 4], array_map(fn (Trackable $item) => $item->id, $tracker->calls[1]['request']->items));
+        self::assertSame([5], array_map(fn (Trackable $item) => $item->id, $tracker->calls[2]['request']->items));
+        self::assertCount(5, $request->items, 'Original request should remain unchanged');
+    }
+
+    public function testSearcherBatchSearchAggregatesChunkResponses(): void
+    {
+        $searcher = new class('dataset-id', 'api-key') extends Searcher {
+            public array $calls = [];
+            /** @var array<int, mixed> */
+            public array $queuedResponses = [];
+
+            public function queueResponse(array $response): void
+            {
+                $this->queuedResponses[] = $response;
+            }
+
+            public function requestAndValidate(string $endpoint, LicensedRequest $request)
+            {
+                $this->calls[] = ['endpoint' => $endpoint, 'request' => $request];
+                return array_shift($this->queuedResponses);
+            }
+        };
+
+        $searcher->setBatchSize(2);
+
+        $request = new SearchRequestCollection();
+        $request->setRequestsFromArray([
+            $this->createSearchRequest(1),
+            $this->createSearchRequest(2),
+            $this->createSearchRequest(3),
+        ]);
+
+        $searcher->queueResponse($this->createSearchResponseCollectionPayload([1, 2]));
+        $searcher->queueResponse($this->createSearchResponseCollectionPayload([3]));
+
+        $result = $searcher->batchsearch($request);
+
+        self::assertInstanceOf(SearchResponseCollection::class, $result);
+        self::assertCount(2, $searcher->calls);
+        self::assertSame('SearchRequestCollection', $searcher->calls[0]['endpoint']);
+        self::assertSame('SearchRequestCollection', $searcher->calls[1]['endpoint']);
+        self::assertNotSame($request, $searcher->calls[0]['request']);
+        self::assertSame([1, 2], array_map(fn (SearchRequest $req) => $req->id, $searcher->calls[0]['request']->requests));
+        self::assertSame([3], array_map(fn (SearchRequest $req) => $req->id, $searcher->calls[1]['request']->requests));
+        self::assertSame([1, 2, 3], array_map(fn ($response) => $response->hits, $result->responses));
+        self::assertCount(3, $request->requests, 'Original request should remain unchanged');
+    }
+
+    public function testRecommenderBatchProductRecommendationMergesResponses(): void
+    {
+        $recommender = new class('dataset-id', 'api-key') extends Recommender {
+            public array $calls = [];
+            /** @var array<int, mixed> */
+            public array $queuedResponses = [];
+
+            public function queueResponse(array $response): void
+            {
+                $this->queuedResponses[] = $response;
+            }
+
+            public function requestAndValidate(string $endpoint, LicensedRequest $request)
+            {
+                $this->calls[] = ['endpoint' => $endpoint, 'request' => $request];
+                return array_shift($this->queuedResponses);
+            }
+        };
+
+        $recommender->setBatchSize(2);
+
+        $requestCollection = new ProductRecommendationRequestCollection();
+        $requestCollection->requireDistinctProductsAcrossResults = true;
+        $requestCollection->setRequestsFromArray([
+            $this->createProductRecommendationRequest(1),
+            $this->createProductRecommendationRequest(2),
+            $this->createProductRecommendationRequest(3),
+        ]);
+
+        $recommender->queueResponse($this->createProductRecommendationResponseCollectionPayload([1, 2]));
+        $recommender->queueResponse($this->createProductRecommendationResponseCollectionPayload([3]));
+
+        $result = $recommender->batchproductRecommendation($requestCollection);
+
+        self::assertInstanceOf(ProductRecommendationResponseCollection::class, $result);
+        self::assertCount(2, $recommender->calls);
+        self::assertSame('ProductRecommendationRequestCollection', $recommender->calls[0]['endpoint']);
+        self::assertSame('ProductRecommendationRequestCollection', $recommender->calls[1]['endpoint']);
+        self::assertNotSame($requestCollection, $recommender->calls[0]['request']);
+        self::assertSame([1, 2], array_map(fn (ProductRecommendationRequest $req) => $req->id, $recommender->calls[0]['request']->requests));
+        self::assertSame([3], array_map(fn (ProductRecommendationRequest $req) => $req->id, $recommender->calls[1]['request']->requests));
+        self::assertSame(
+            ['product-1', 'product-2', 'product-3'],
+            array_map(
+                fn ($response) => $response->recommendations[0]->productId,
+                $result->responses
+            )
+        );
+        self::assertCount(3, $requestCollection->requests, 'Original request should remain unchanged');
+        self::assertTrue($requestCollection->requireDistinctProductsAcrossResults);
+    }
+
+    private function createTrackable(int $id): Trackable
+    {
+        return new class($id) extends Trackable {
+            public function __construct(public int $id)
+            {
+            }
+        };
+    }
+
+    private function createSearchRequest(int $id): SearchRequest
+    {
+        return new class($id) extends SearchRequest {
+            public function __construct(public int $id)
+            {
+            }
+        };
+    }
+
+    private function createProductRecommendationRequest(int $id): ProductRecommendationRequest
+    {
+        return new class($id) extends ProductRecommendationRequest {
+            public function __construct(public int $id)
+            {
+            }
+        };
+    }
+
+    /**
+     * @param array<int, int> $hits
+     */
+    private function createSearchResponseCollectionPayload(array $hits): array
+    {
+        return [
+            '\$type' => 'Relewise.Client.Responses.Search.SearchResponseCollection, Relewise.Client',
+            'responses' => array_map(
+                fn (int $hit) => [
+                    '\$type' => 'Relewise.Client.Responses.Search.ProductSearchResponse, Relewise.Client',
+                    'hits' => $hit,
+                    'results' => [],
+                ],
+                $hits
+            ),
+        ];
+    }
+
+    /**
+     * @param array<int, int> $ids
+     */
+    private function createProductRecommendationResponseCollectionPayload(array $ids): array
+    {
+        return [
+            '\$type' => 'Relewise.Client.Responses.ProductRecommendationResponseCollection, Relewise.Client',
+            'responses' => array_map(
+                fn (int $id) => [
+                    '\$type' => 'Relewise.Client.Responses.ProductRecommendationResponse, Relewise.Client',
+                    'recommendations' => [
+                        [
+                            'productId' => 'product-' . $id,
+                            'rank' => $id,
+                        ],
+                    ],
+                ],
+                $ids
+            ),
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
- update the PHP client generator to detect batchable requests and emit chunked request handling
- expose a configurable batch size on the shared client base class
- update generated tracker, searcher, and recommender batch methods to chunk requests and merge responses
- add PHPUnit unit tests covering tracker, searcher, and recommender batching behavior

## Testing
- composer validate
- (failed) composer install (packagist returned 403 while resolving dependencies for phpunit)

------
https://chatgpt.com/codex/tasks/task_b_68d255c18ec8832cbd771bdad0f88823