### PR TITLE
Ensure generator respects create method parameters

### DIFF
--- a/src/Models/ProductDataRelevanceModifier.php
+++ b/src/Models/ProductDataRelevanceModifier.php
@@ -22,7 +22,6 @@ class ProductDataRelevanceModifier extends DataRelevanceModifier
         $result->multiplierSelector = $multiplierSelector;
         $result->mustMatchAllConditions = $mustMatchAllConditions;
         $result->considerAsMatchIfKeyIsNotFound = $considerAsMatchIfKeyIsNotFound;
-        $result->mustMatchAllConditions = true;
         return $result;
     }
     

--- a/src/Models/VariantDataRelevanceModifier.php
+++ b/src/Models/VariantDataRelevanceModifier.php
@@ -22,7 +22,6 @@ class VariantDataRelevanceModifier extends DataRelevanceModifier
         $result->multiplierSelector = $multiplierSelector;
         $result->mustMatchAllConditions = $mustMatchAllConditions;
         $result->considerAsMatchIfKeyIsNotFound = $considerAsMatchIfKeyIsNotFound;
-        $result->mustMatchAllConditions = true;
         return $result;
     }
     


### PR DESCRIPTION
## Summary
- track the constructor parameters selected during generation so default assignments are not reapplied
- ensure ProductDataRelevanceModifier and VariantDataRelevanceModifier create helpers preserve the provided mustMatchAllConditions flag

## Testing
- ./generate.sh *(fails: dotnet not installed in container)*

------
https://chatgpt.com/codex/tasks/task_b_68e64524bec4832c9368bea841e77ae9

https://trello.com/c/eAv1QLBo/12811-possible-bug-in-setrelevancemodifiers-php