### PR TITLE
fix(skills): prevent PR description encoding corruption

### DIFF
--- a/.agents/skills/update-sdk/SKILL.md
+++ b/.agents/skills/update-sdk/SKILL.md
@@ -135,8 +135,9 @@ git push -u origin $branchName
 Preferred flow with GitHub CLI:
 ```powershell
 $prBodyPath = ".\\update-sdk-pr-body.md"
-@"
-$TrelloCardUrl
+$prBodyTemplate = @'
+__TRELLO_CARD_URL__
+
 
 ## Summary
 - Regenerated PHP SDK code via Generator
@@ -150,7 +151,9 @@ $TrelloCardUrl
 
 ## Notes
 - <known issues or limitations>
-"@ | Set-Content $prBodyPath
+'@
+$prBody = $prBodyTemplate -replace '__TRELLO_CARD_URL__', $TrelloCardUrl
+Set-Content -Path $prBodyPath -Value $prBody -Encoding utf8
 
 $prUrl = gh pr create --base main --head $branchName --title "chore(php): update sdk generation ($stamp)" --body-file $prBodyPath
 if ($LASTEXITCODE -ne 0) { throw 'gh pr create failed.' }
@@ -166,6 +169,7 @@ Write-Host "PR body file: $prBodyPath"
 ```
 
 Keep the Trello URL as the first line of the PR description.
+Write the PR body file as UTF-8 to avoid symbol corruption in GitHub-rendered text.
 
 ## Output Expectations
 Provide a final summary with:


### PR DESCRIPTION
## Summary
- Update skill PR-body instructions to avoid encoding-related symbol corruption in GitHub-rendered PR descriptions.
- Replace interpolated here-string PR body generation with a safe template + Trello URL replacement pattern.
- Write PR body files explicitly as UTF-8 (Set-Content -Encoding utf8).

## Scope
- SKILL instructions only (SKILL.md).
- No runtime application code, configs, or dependencies changed.

## Validation
- Confirmed old @" ... | Set-Content C:\Users\mail\AppData\Local\Temp\pr-body-relewise-sdk-php.md pattern was removed.
- Confirmed __TRELLO_CARD_URL__ templating and UTF-8 write instructions are present.
