### PR TITLE
fix: Correct interface support

### DIFF
--- a/Generator/Constants.cs
+++ b/Generator/Constants.cs
@@ -3,5 +3,7 @@
 public class Constants
 {
     public const string Namespace = "Relewise\\Models";
+    public const string InternalNamespace = "Relewise\\Models\\Internal";
     public const string GenerationFolderPath = "Models";
+    public const string InternalGenerationFolderPath = "Models/Internal";
 }

--- a/Generator/PhpMemberWriters/PhpHydrationMethodsWriter.cs
+++ b/Generator/PhpMemberWriters/PhpHydrationMethodsWriter.cs
@@ -13,7 +13,7 @@ public class PhpHydrationMethodsWriter
         this.phpWriter = phpWriter;
     }
 
-    public void Write(IndentedTextWriter writer, Type type, string typeName, (PropertyInfo info, string propertyTypeName, string propertyName, string lowerCaseName)[] propertyInformations)
+    public void Write(IndentedTextWriter writer, Type type, string typeName, (PropertyInfo info, string propertyTypeName, string propertyName, string lowerCaseName)[] propertyInformations, bool internalContext = false)
     {
         if (type.IsAbstract || type.IsInterface)
         {
@@ -37,7 +37,7 @@ public class PhpHydrationMethodsWriter
                 writer.WriteLine($"if ($type==\"{derivedType.FullName}, {type.Assembly.FullName?.Split(",")[0]}\")");
                 writer.WriteLine("{");
                 writer.Indent++;
-                writer.WriteLine($"return {phpWriter.PhpTypeName(derivedType)}::hydrate($arr);");
+                writer.WriteLine($"return {ModelTypeReference(derivedType, internalContext)}::hydrate($arr);");
                 writer.Indent--;
                 writer.WriteLine("}");
             }
@@ -51,11 +51,11 @@ public class PhpHydrationMethodsWriter
             writer.Indent++;
             if (type.BaseType is { IsAbstract: true } abstractBase)
             {
-                writer.WriteLine($"$result = {phpWriter.PhpTypeName(abstractBase).Replace("?", "")}::hydrateBase($result, $arr);");
+                writer.WriteLine($"$result = {ModelTypeReference(abstractBase, internalContext)}::hydrateBase($result, $arr);");
             }
             foreach (var (info, _, _, lowerCaseName) in propertyInformations)
             {
-                WriteHydrationSetter(writer, info.PropertyType, lowerCaseName);
+                WriteHydrationSetter(writer, info.PropertyType, lowerCaseName, internalContext);
             }
             writer.WriteLine("return $result;");
             writer.Indent--;
@@ -69,7 +69,7 @@ public class PhpHydrationMethodsWriter
             writer.Indent++;
             if (type.BaseType != typeof(ValueType) && type.BaseType is { IsAbstract: true } abstractBase)
             {
-                writer.WriteLine($"$result = {phpWriter.PhpTypeName(abstractBase).Replace("?", "")}::hydrateBase(new {typeName}(), $arr);");
+                writer.WriteLine($"$result = {ModelTypeReference(abstractBase, internalContext)}::hydrateBase(new {typeName}(), $arr);");
             }
             // In this case the base type won't expose a hydrate method we can use
             // We need to handle the base type's props manually
@@ -80,12 +80,12 @@ public class PhpHydrationMethodsWriter
                 // If the base class has a base class we need to reuse that class' hydrateBase method
                 writer.WriteLine(type.BaseType.BaseType != null &&
                                  type.BaseType.BaseType != typeof(object)
-                    ? $"$result = {phpWriter.PhpTypeName(type.BaseType.BaseType).Replace("?", "")}::hydrateBase(new {typeName}(), $arr);"
+                    ? $"$result = {ModelTypeReference(type.BaseType.BaseType, internalContext)}::hydrateBase(new {typeName}(), $arr);"
                     : $"$result = new {typeName}();");
 
                 foreach (PropertyInfo props in type.BaseType.FindOwnedPropertyInfos())
                 { 
-                    WriteHydrationSetter(writer, props.PropertyType, props.Name.ToCamelCase());
+                    WriteHydrationSetter(writer, props.PropertyType, props.Name.ToCamelCase(), internalContext);
                 }
             }
             else
@@ -95,7 +95,7 @@ public class PhpHydrationMethodsWriter
 
             foreach (var (info, _, _, lowerCaseName) in propertyInformations)
             {
-                WriteHydrationSetter(writer, info.PropertyType, lowerCaseName);
+                WriteHydrationSetter(writer, info.PropertyType, lowerCaseName, internalContext);
             }
             writer.WriteLine($"return $result;");
             writer.Indent--;
@@ -103,62 +103,62 @@ public class PhpHydrationMethodsWriter
         }
     }
 
-    private void WriteHydrationSetter(IndentedTextWriter writer, Type propertyType, string lowerCaseName)
+    private void WriteHydrationSetter(IndentedTextWriter writer, Type propertyType, string lowerCaseName, bool internalContext)
     {
         writer.WriteLine($"if (array_key_exists(\"{lowerCaseName}\", $arr))");
         writer.WriteLine("{");
         writer.Indent++;
         if (propertyType.IsArray && propertyType.GetElementType() is { } elementType)
         {
-            WriteArrayLikeHydrationSetter(writer, elementType, lowerCaseName);
+            WriteArrayLikeHydrationSetter(writer, elementType, lowerCaseName, internalContext);
         }
         else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(List<>))
         {
-            WriteArrayLikeHydrationSetter(writer, propertyType.GenericTypeArguments.Single(), lowerCaseName);
+            WriteArrayLikeHydrationSetter(writer, propertyType.GenericTypeArguments.Single(), lowerCaseName, internalContext);
         }
         else if (propertyType.IsGenericType && propertyType.GetGenericTypeDefinition() == typeof(Dictionary<,>))
         {
-            WriteDictionaryHydrationSetter(writer, propertyType.GenericTypeArguments[0], propertyType.GenericTypeArguments[1], lowerCaseName);
+            WriteDictionaryHydrationSetter(writer, propertyType.GenericTypeArguments[0], propertyType.GenericTypeArguments[1], lowerCaseName, internalContext);
         }
         else
         {
-            writer.WriteLine($"$result->{lowerCaseName} = {HydrationExpression(propertyType, $"$arr[\"{lowerCaseName}\"]")};");
+            writer.WriteLine($"$result->{lowerCaseName} = {HydrationExpression(propertyType, $"$arr[\"{lowerCaseName}\"]", internalContext)};");
         }
         writer.Indent--;
         writer.WriteLine("}");
     }
 
-    private void WriteArrayLikeHydrationSetter(IndentedTextWriter writer, Type elementType, string lowerCaseName)
+    private void WriteArrayLikeHydrationSetter(IndentedTextWriter writer, Type elementType, string lowerCaseName, bool internalContext)
     {
         writer.WriteLine($"$result->{lowerCaseName} = array();");
         writer.WriteLine($"foreach($arr[\"{lowerCaseName}\"] as &$value)");
         writer.WriteLine("{");
         writer.Indent++;
-        writer.WriteLine($"array_push($result->{lowerCaseName}, {HydrationExpression(elementType, "$value")});");
+        writer.WriteLine($"array_push($result->{lowerCaseName}, {HydrationExpression(elementType, "$value", internalContext)});");
         writer.Indent--;
         writer.WriteLine("}");
     }
 
-    private void WriteDictionaryHydrationSetter(IndentedTextWriter writer, Type keyType, Type valueType, string lowerCaseName)
+    private void WriteDictionaryHydrationSetter(IndentedTextWriter writer, Type keyType, Type valueType, string lowerCaseName, bool internalContext)
     {
         writer.WriteLine($"$result->{lowerCaseName} = array();");
         writer.WriteLine($"foreach($arr[\"{lowerCaseName}\"] as $key => $value)");
         writer.WriteLine("{");
         writer.Indent++;
-        writer.WriteLine($"$result->{lowerCaseName}[{HydrationExpression(keyType, "$key")}] = {HydrationExpression(valueType, "$value")};");
+        writer.WriteLine($"$result->{lowerCaseName}[{HydrationExpression(keyType, "$key", internalContext)}] = {HydrationExpression(valueType, "$value", internalContext)};");
         writer.Indent--;
         writer.WriteLine("}");
     }
 
-    private string HydrationExpression(Type type, string jsonValue)
+    private string HydrationExpression(Type type, string jsonValue, bool internalContext)
     {
         if (Nullable.GetUnderlyingType(type) is { } underlyingType)
         {
-            return HydrationExpression(underlyingType, jsonValue);
+            return HydrationExpression(underlyingType, jsonValue, internalContext);
         }
         if (type.IsEnum)
         {
-            return $"{phpWriter.PhpTypeName(type)}::from({jsonValue})";
+            return $"{ModelTypeReference(type, internalContext)}::from({jsonValue})";
         }
         if (type == typeof(DateTimeOffset) || type == typeof(DateTime))
         {
@@ -170,7 +170,7 @@ public class PhpHydrationMethodsWriter
         }
         if (type.IsInterface)
         {
-            return $"{phpWriter.HydratorTypeName(type)}::hydrate({jsonValue})";
+            return $"{InternalTypeReference(type, internalContext)}::hydrate({jsonValue})";
         }
         if (type.IsPrimitive ||
             type == typeof(string) ||
@@ -184,6 +184,18 @@ public class PhpHydrationMethodsWriter
         {
             return jsonValue;
         }
-        return $"{phpWriter.PhpTypeName(type).Replace("?", "")}::hydrate({jsonValue})";
+        return $"{ModelTypeReference(type, internalContext)}::hydrate({jsonValue})";
+    }
+
+    private string ModelTypeReference(Type type, bool internalContext)
+    {
+        var typeName = phpWriter.PhpTypeName(type).Replace("?", string.Empty);
+        return internalContext ? $"Models\\{typeName}" : typeName;
+    }
+
+    private string InternalTypeReference(Type type, bool internalContext)
+    {
+        var typeName = phpWriter.HydratorTypeName(type);
+        return internalContext ? typeName : $"Internal\\{typeName}";
     }
 }

--- a/Generator/PhpMemberWriters/PhpHydrationMethodsWriter.cs
+++ b/Generator/PhpMemberWriters/PhpHydrationMethodsWriter.cs
@@ -168,6 +168,10 @@ public class PhpHydrationMethodsWriter
         {
             return $"DateIntervalFactory::fromTimeSpanString({jsonValue})";
         }
+        if (type.IsInterface)
+        {
+            return $"{phpWriter.HydratorTypeName(type)}::hydrate({jsonValue})";
+        }
         if (type.IsPrimitive ||
             type == typeof(string) ||
             type == typeof(Guid) ||

--- a/Generator/PhpTypeResolver.cs
+++ b/Generator/PhpTypeResolver.cs
@@ -1,4 +1,5 @@
-﻿using System.Reflection;
+﻿using System.Diagnostics.CodeAnalysis;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Generator;
@@ -33,6 +34,17 @@ public class PhpTypeResolver
 
     public bool IsWritten(string typeName) => GeneratedFileNames.Contains(typeName);
     public void HasWritten(string typeName) => GeneratedFileNames.Add(typeName);
+
+    public bool TryGetKnownTypeName(Type type, [NotNullWhen(true)] out string? typeName)
+    {
+        if (typeDefintions.TryGetValue(type, out typeName!))
+        {
+            return true;
+        }
+
+        typeName = null;
+        return false;
+    }
 
     private string GetOrAddTypeDefinition(Type type)
     {

--- a/Generator/PhpTypeWriters/IPhpTypeWriter.cs
+++ b/Generator/PhpTypeWriters/IPhpTypeWriter.cs
@@ -5,5 +5,6 @@ namespace Generator.PhpTypeWriters;
 public interface IPhpTypeWriter
 {
     public bool CanWrite(Type type);
+    public string GetFileName(Type type, string typeName);
     public void Write(IndentedTextWriter writer, Type type, string typeName);
 }

--- a/Generator/PhpTypeWriters/PhpClassWriter.cs
+++ b/Generator/PhpTypeWriters/PhpClassWriter.cs
@@ -27,6 +27,8 @@ public class PhpClassWriter : IPhpTypeWriter
 
     public bool CanWrite(Type type) => IsClass(type) || IsAnyStruct(type);
 
+    public string GetFileName(Type type, string typeName) => $"{typeName}.php";
+
     private bool IsClass(Type type) => type.IsClass;
 
     private bool IsReadonlyStruct(Type type) => type.IsValueType && type.GetProperties().All(p => !p.CanWrite);
@@ -96,6 +98,18 @@ public class PhpClassWriter : IPhpTypeWriter
             baseTypeName = $"{type.Name}Extractable";
         }
 
+        var implementedInterfaces = type.GetInterfaces()
+            .Where(interfaceType => interfaceType.Assembly == type.Assembly && interfaceType.IsInterface)
+            .Select(interfaceType =>
+                phpWriter.TryGetKnownTypeName(interfaceType, out var knownTypeName)
+                    ? knownTypeName.Replace("?", string.Empty)
+                    : null)
+            .Where(interfaceName => interfaceName is not null)
+            .Select(interfaceName => interfaceName!)
+            .Distinct()
+            .OrderBy(interfaceName => interfaceName)
+            .ToArray();
+
         var deprecationComment = type.GetCustomAttribute(typeof(ObsoleteAttribute)) is ObsoleteAttribute { } obsolete ? $"@deprecated {obsolete.Message}" : null;
 
         writer.WriteCommentBlock(
@@ -112,9 +126,11 @@ public class PhpClassWriter : IPhpTypeWriter
         {
             writer.Write($" extends {baseTypeName}");
         }
-        if (hasDateTimeOrDateTimeOffsetProperty)
+        if (implementedInterfaces.Length > 0 || hasDateTimeOrDateTimeOffsetProperty)
         {
-            writer.Write(" implements JsonSerializable");
+            writer.Write(" implements ");
+            var implementedTypes = implementedInterfaces.Concat(hasDateTimeOrDateTimeOffsetProperty ? ["JsonSerializable"] : Array.Empty<string>());
+            writer.Write(string.Join(", ", implementedTypes));
         }
         writer.WriteLine();
 

--- a/Generator/PhpTypeWriters/PhpInterfaceHydratorWriter.cs
+++ b/Generator/PhpTypeWriters/PhpInterfaceHydratorWriter.cs
@@ -1,21 +1,21 @@
-﻿using System.CodeDom.Compiler;
-using System.Reflection;
 using Generator.Extensions;
+using System.CodeDom.Compiler;
+using System.Reflection;
 
 namespace Generator.PhpTypeWriters;
 
-internal class PhpEnumWriter : IPhpTypeWriter
+internal class PhpInterfaceHydratorWriter : IPhpTypeWriter
 {
     private readonly PhpWriter phpWriter;
 
-    public PhpEnumWriter(PhpWriter phpWriter)
+    public PhpInterfaceHydratorWriter(PhpWriter phpWriter)
     {
         this.phpWriter = phpWriter;
     }
 
-    public bool CanWrite(Type type) => type.IsEnum;
+    public bool CanWrite(Type type) => type.IsInterface;
 
-    public string GetFileName(Type type, string typeName) => $"{typeName}.php";
+    public string GetFileName(Type type, string typeName) => $"{phpWriter.HydratorTypeName(type)}.php";
 
     public void Write(IndentedTextWriter writer, Type type, string typeName)
     {
@@ -23,27 +23,21 @@ internal class PhpEnumWriter : IPhpTypeWriter
 <?php declare(strict_types=1);
 
 namespace {Constants.Namespace};
-
-use DateTime;
-
 """);
+        writer.WriteLine();
 
         var deprecationComment = type.GetCustomAttribute(typeof(ObsoleteAttribute)) is ObsoleteAttribute { } obsolete ? $"@deprecated {obsolete.Message}" : null;
 
         writer.WriteCommentBlock(
             phpWriter.XmlDocumentation.GetSummary(type),
+            "Hydrator helper for this interface.",
             deprecationComment
         );
 
-        writer.WriteLine($"enum {typeName} : string");
+        writer.WriteLine($"class {phpWriter.HydratorTypeName(type)}");
         writer.WriteLine("{");
         writer.Indent++;
-        foreach (var enumMember in type.GetMembers().Where(propertyInfo => propertyInfo.DeclaringType is { IsEnum: true } && propertyInfo.Name is not "__value" and not "value__"))
-        {
-            writer.WriteCommentBlock(phpWriter.XmlDocumentation.GetSummary(type, enumMember.Name));
-
-            writer.WriteLine($"case {enumMember.Name} = '{enumMember.Name}';");
-        }
+        phpWriter.PhpHydrationMethodsWriter.Write(writer, type, typeName, []);
         writer.Indent--;
         writer.WriteLine("}");
     }

--- a/Generator/PhpTypeWriters/PhpInterfaceHydratorWriter.cs
+++ b/Generator/PhpTypeWriters/PhpInterfaceHydratorWriter.cs
@@ -22,7 +22,9 @@ internal class PhpInterfaceHydratorWriter : IPhpTypeWriter
         writer.WriteLine($"""
 <?php declare(strict_types=1);
 
-namespace {Constants.Namespace};
+namespace {Constants.InternalNamespace};
+
+use Relewise\Models;
 """);
         writer.WriteLine();
 
@@ -37,7 +39,7 @@ namespace {Constants.Namespace};
         writer.WriteLine($"class {phpWriter.HydratorTypeName(type)}");
         writer.WriteLine("{");
         writer.Indent++;
-        phpWriter.PhpHydrationMethodsWriter.Write(writer, type, typeName, []);
+        phpWriter.PhpHydrationMethodsWriter.Write(writer, type, typeName, [], internalContext: true);
         writer.Indent--;
         writer.WriteLine("}");
     }

--- a/Generator/PhpTypeWriters/PhpInterfaceWriter.cs
+++ b/Generator/PhpTypeWriters/PhpInterfaceWriter.cs
@@ -1,4 +1,4 @@
-﻿using Generator.Extensions;
+using Generator.Extensions;
 using System.CodeDom.Compiler;
 using System.Reflection;
 
@@ -15,14 +15,14 @@ internal class PhpInterfaceWriter : IPhpTypeWriter
 
     public bool CanWrite(Type type) => type.IsInterface;
 
+    public string GetFileName(Type type, string typeName) => $"{typeName}.php";
+
     public void Write(IndentedTextWriter writer, Type type, string typeName)
     {
         writer.WriteLine($"""
 <?php declare(strict_types=1);
 
 namespace {Constants.Namespace};
-
-use DateTime;
 
 """);
         var deprecationComment = type.GetCustomAttribute(typeof(ObsoleteAttribute)) is ObsoleteAttribute { } obsolete ? $"@deprecated {obsolete.Message}" : null;
@@ -33,10 +33,9 @@ use DateTime;
             deprecationComment
         );
 
-        writer.WriteLine($"abstract class {typeName}");
+        writer.WriteLine($"interface {typeName}");
         writer.WriteLine("{");
         writer.Indent++;
-        phpWriter.PhpHydrationMethodsWriter.Write(writer, type, typeName, Array.Empty<(PropertyInfo, string, string, string)>());
         writer.Indent--;
         writer.WriteLine("}");
     }

--- a/Generator/PhpTypeWriters/PhpKeyValuePairWriter.cs
+++ b/Generator/PhpTypeWriters/PhpKeyValuePairWriter.cs
@@ -13,6 +13,8 @@ internal class PhpKeyValuePairWriter : IPhpTypeWriter
 
     public bool CanWrite(Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(KeyValuePair<,>);
 
+    public string GetFileName(Type type, string typeName) => $"{typeName}.php";
+
     public void Write(IndentedTextWriter writer, Type type, string typeName)
     {
         writer.WriteLine($"""

--- a/Generator/PhpWriter.cs
+++ b/Generator/PhpWriter.cs
@@ -83,7 +83,14 @@ public class PhpWriter
                         continue;
                     }
 
-                    using StreamWriter streamWriter = File.CreateText($"{BasePath}/{Constants.GenerationFolderPath}/{fileName}");
+                    var generationFolderPath = phpTypeWriter is PhpInterfaceHydratorWriter
+                        ? Constants.InternalGenerationFolderPath
+                        : Constants.GenerationFolderPath;
+
+                    var outputDirectory = Path.Combine(BasePath, generationFolderPath);
+                    Directory.CreateDirectory(outputDirectory);
+
+                    using StreamWriter streamWriter = File.CreateText(Path.Combine(outputDirectory, fileName));
                     using var writer = new IndentedTextWriter(streamWriter);
 
                     phpTypeWriter.Write(writer, type, typeName);

--- a/Generator/PhpWriter.cs
+++ b/Generator/PhpWriter.cs
@@ -1,6 +1,7 @@
 ﻿using Generator.PhpMemberWriters;
 using Generator.PhpTypeWriters;
 using System.CodeDom.Compiler;
+using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 
 namespace Generator;
@@ -9,6 +10,7 @@ public class PhpWriter
 {
     private readonly List<IPhpTypeWriter> _phpTypeWriters;
     private readonly PhpTypeResolver _phpTypeResolver;
+    private readonly HashSet<Type> _processedTypes = new();
 
     public HashSet<Type> MissingTypeDefinitions { get; set; } = new();
     public Assembly Assembly { get; }
@@ -23,7 +25,7 @@ public class PhpWriter
 
     public PhpWriter(Assembly assembly, string basePath, XmlDocumentation xmlDocumentation)
     {
-        _phpTypeWriters = new List<IPhpTypeWriter> { new PhpInterfaceWriter(this), new PhpEnumWriter(this), new PhpKeyValuePairWriter(this), new PhpClassWriter(this) };
+        _phpTypeWriters = new List<IPhpTypeWriter> { new PhpInterfaceWriter(this), new PhpInterfaceHydratorWriter(this), new PhpEnumWriter(this), new PhpKeyValuePairWriter(this), new PhpClassWriter(this) };
         _phpTypeResolver = new PhpTypeResolver(assembly);
         Assembly = assembly;
         BasePath = basePath;
@@ -59,20 +61,34 @@ public class PhpWriter
             if ((type.IsGenericTypeDefinition || type.IsGenericTypeParameter || typeName.Contains("d__")))
                 continue;
 
+            if (!_processedTypes.Add(type))
+            {
+                continue;
+            }
+
             DiscoverReferencedTypesFromSignatures(type);
 
-            using StreamWriter streamWriter = File.CreateText($"{BasePath}/{Constants.GenerationFolderPath}/{typeName}.php");
-            using var writer = new IndentedTextWriter(streamWriter);
-
-            IPhpTypeWriter? phpTypeWriter = _phpTypeWriters.FirstOrDefault(w => w.CanWrite(type));
-            if (phpTypeWriter is null)
+            var phpTypeWriters = _phpTypeWriters.Where(w => w.CanWrite(type)).ToArray();
+            if (phpTypeWriters.Length == 0)
             {
                 MissingTypeDefinitions.Add(type);
             }
             else
             {
-                phpTypeWriter.Write(writer, type, typeName);
-                _phpTypeResolver.HasWritten(typeName);
+                foreach (var phpTypeWriter in phpTypeWriters)
+                {
+                    string fileName = phpTypeWriter.GetFileName(type, typeName);
+                    if (_phpTypeResolver.IsWritten(fileName))
+                    {
+                        continue;
+                    }
+
+                    using StreamWriter streamWriter = File.CreateText($"{BasePath}/{Constants.GenerationFolderPath}/{fileName}");
+                    using var writer = new IndentedTextWriter(streamWriter);
+
+                    phpTypeWriter.Write(writer, type, typeName);
+                    _phpTypeResolver.HasWritten(fileName);
+                }
             }
         }
     }
@@ -187,6 +203,10 @@ public class PhpWriter
         var typeName = PhpTypeName(property.ParameterType);
         return PrependNullableIfApplicable(typeName, new NullabilityInfoContext().Create(property));
     }
+
+    public bool TryGetKnownTypeName(Type type, [NotNullWhen(true)] out string? typeName) => _phpTypeResolver.TryGetKnownTypeName(type, out typeName);
+
+    public string HydratorTypeName(Type type) => $"{PhpTypeName(type).Replace("?", string.Empty)}Hydrator";
 
     private static string PrependNullableIfApplicable(string typeName, NullabilityInfo nullabilityInfo)
     {

--- a/src/Models/AbandonedCartTriggerResult.php
+++ b/src/Models/AbandonedCartTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class AbandonedCartTriggerResult
+class AbandonedCartTriggerResult implements ITriggerResult
 {
     public UserResultDetails $user;
     

--- a/src/Models/AbandonedSearchTriggerResult.php
+++ b/src/Models/AbandonedSearchTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class AbandonedSearchTriggerResult
+class AbandonedSearchTriggerResult implements ITriggerResult
 {
     public UserResultDetails $user;
     public SearchType $type;

--- a/src/Models/Campaign.php
+++ b/src/Models/Campaign.php
@@ -35,7 +35,7 @@ class Campaign extends CampaignEntityStatestringCampaignMetadataValuesRetailMedi
         }
         if (array_key_exists("schedule", $arr))
         {
-            $result->schedule = ISchedule::hydrate($arr["schedule"]);
+            $result->schedule = Internal\IScheduleHydrator::hydrate($arr["schedule"]);
         }
         if (array_key_exists("promotions", $arr))
         {

--- a/src/Models/Change.php
+++ b/src/Models/Change.php
@@ -3,7 +3,7 @@
 namespace Relewise\Models;
 
 /** Indicates that some property should change by having a new value which is still of the same type. */
-class Change
+class Change implements IChange
 {
     public static function create() : Change
     {

--- a/src/Models/ContentCategoryInterestTriggerResult.php
+++ b/src/Models/ContentCategoryInterestTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class ContentCategoryInterestTriggerResult
+class ContentCategoryInterestTriggerResult implements ITriggerResult
 {
     public UserResultDetails $user;
     public array $categories;

--- a/src/Models/Decrease.php
+++ b/src/Models/Decrease.php
@@ -3,7 +3,7 @@
 namespace Relewise\Models;
 
 /** Indicates that some property should change by decreasing in value. */
-class Decrease
+class Decrease implements IChange
 {
     public static function create() : Decrease
     {

--- a/src/Models/EntityChangeTriggerResult.php
+++ b/src/Models/EntityChangeTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-abstract class EntityChangeTriggerResult
+abstract class EntityChangeTriggerResult implements ITriggerResult
 {
     public string $typeDefinition = "";
     public UserResultDetails $user;

--- a/src/Models/IChange.php
+++ b/src/Models/IChange.php
@@ -2,31 +2,7 @@
 
 namespace Relewise\Models;
 
-use DateTime;
-
 /** This is actually an interface. */
-abstract class IChange
+interface IChange
 {
-    
-    public static function hydrate(array $arr)
-    {
-        $type = $arr["\$type"];
-        if ($type=="Relewise.Client.DataTypes.Changes.Change, Relewise.Client")
-        {
-            return Change::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.DataTypes.Changes.Decrease, Relewise.Client")
-        {
-            return Decrease::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.DataTypes.Changes.Increase, Relewise.Client")
-        {
-            return Increase::hydrate($arr);
-        }
-    }
-    
-    public static function hydrateBase(mixed $result, array $arr)
-    {
-        return $result;
-    }
 }

--- a/src/Models/ISchedule.php
+++ b/src/Models/ISchedule.php
@@ -2,23 +2,7 @@
 
 namespace Relewise\Models;
 
-use DateTime;
-
 /** This is actually an interface. */
-abstract class ISchedule
+interface ISchedule
 {
-    
-    public static function hydrate(array $arr)
-    {
-        $type = $arr["\$type"];
-        if ($type=="Relewise.Client.DataTypes.Scheduling.ScheduledPeriod, Relewise.Client")
-        {
-            return ScheduledPeriod::hydrate($arr);
-        }
-    }
-    
-    public static function hydrateBase(mixed $result, array $arr)
-    {
-        return $result;
-    }
 }

--- a/src/Models/ITriggerResult.php
+++ b/src/Models/ITriggerResult.php
@@ -2,51 +2,7 @@
 
 namespace Relewise\Models;
 
-use DateTime;
-
 /** This is actually an interface. */
-abstract class ITriggerResult
+interface ITriggerResult
 {
-    
-    public static function hydrate(array $arr)
-    {
-        $type = $arr["\$type"];
-        if ($type=="Relewise.Client.Responses.Triggers.Results.AbandonedCartTriggerResult, Relewise.Client")
-        {
-            return AbandonedCartTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.AbandonedSearchTriggerResult, Relewise.Client")
-        {
-            return AbandonedSearchTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.ContentCategoryInterestTriggerResult, Relewise.Client")
-        {
-            return ContentCategoryInterestTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.ProductCategoryInterestTriggerResult, Relewise.Client")
-        {
-            return ProductCategoryInterestTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.ProductChangeTriggerResult, Relewise.Client")
-        {
-            return ProductChangeTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.ProductInterestTriggerResult, Relewise.Client")
-        {
-            return ProductInterestTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.UserActivityTriggerResult, Relewise.Client")
-        {
-            return UserActivityTriggerResult::hydrate($arr);
-        }
-        if ($type=="Relewise.Client.Responses.Triggers.Results.VariantChangeTriggerResult, Relewise.Client")
-        {
-            return VariantChangeTriggerResult::hydrate($arr);
-        }
-    }
-    
-    public static function hydrateBase(mixed $result, array $arr)
-    {
-        return $result;
-    }
 }

--- a/src/Models/Increase.php
+++ b/src/Models/Increase.php
@@ -3,7 +3,7 @@
 namespace Relewise\Models;
 
 /** Indicates that some property should change by increasing in value. */
-class Increase
+class Increase implements IChange
 {
     public static function create() : Increase
     {

--- a/src/Models/Internal/IChangeHydrator.php
+++ b/src/Models/Internal/IChangeHydrator.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace Relewise\Models\Internal;
+
+use Relewise\Models;
+
+/** Hydrator helper for this interface. */
+class IChangeHydrator
+{
+    
+    public static function hydrate(array $arr)
+    {
+        $type = $arr["\$type"];
+        if ($type=="Relewise.Client.DataTypes.Changes.Change, Relewise.Client")
+        {
+            return Models\Change::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.DataTypes.Changes.Decrease, Relewise.Client")
+        {
+            return Models\Decrease::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.DataTypes.Changes.Increase, Relewise.Client")
+        {
+            return Models\Increase::hydrate($arr);
+        }
+    }
+    
+    public static function hydrateBase(mixed $result, array $arr)
+    {
+        return $result;
+    }
+}

--- a/src/Models/Internal/IScheduleHydrator.php
+++ b/src/Models/Internal/IScheduleHydrator.php
@@ -1,0 +1,24 @@
+<?php declare(strict_types=1);
+
+namespace Relewise\Models\Internal;
+
+use Relewise\Models;
+
+/** Hydrator helper for this interface. */
+class IScheduleHydrator
+{
+    
+    public static function hydrate(array $arr)
+    {
+        $type = $arr["\$type"];
+        if ($type=="Relewise.Client.DataTypes.Scheduling.ScheduledPeriod, Relewise.Client")
+        {
+            return Models\ScheduledPeriod::hydrate($arr);
+        }
+    }
+    
+    public static function hydrateBase(mixed $result, array $arr)
+    {
+        return $result;
+    }
+}

--- a/src/Models/Internal/ITriggerResultHydrator.php
+++ b/src/Models/Internal/ITriggerResultHydrator.php
@@ -1,0 +1,52 @@
+<?php declare(strict_types=1);
+
+namespace Relewise\Models\Internal;
+
+use Relewise\Models;
+
+/** Hydrator helper for this interface. */
+class ITriggerResultHydrator
+{
+    
+    public static function hydrate(array $arr)
+    {
+        $type = $arr["\$type"];
+        if ($type=="Relewise.Client.Responses.Triggers.Results.AbandonedCartTriggerResult, Relewise.Client")
+        {
+            return Models\AbandonedCartTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.AbandonedSearchTriggerResult, Relewise.Client")
+        {
+            return Models\AbandonedSearchTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.ContentCategoryInterestTriggerResult, Relewise.Client")
+        {
+            return Models\ContentCategoryInterestTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.ProductCategoryInterestTriggerResult, Relewise.Client")
+        {
+            return Models\ProductCategoryInterestTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.ProductChangeTriggerResult, Relewise.Client")
+        {
+            return Models\ProductChangeTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.ProductInterestTriggerResult, Relewise.Client")
+        {
+            return Models\ProductInterestTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.UserActivityTriggerResult, Relewise.Client")
+        {
+            return Models\UserActivityTriggerResult::hydrate($arr);
+        }
+        if ($type=="Relewise.Client.Responses.Triggers.Results.VariantChangeTriggerResult, Relewise.Client")
+        {
+            return Models\VariantChangeTriggerResult::hydrate($arr);
+        }
+    }
+    
+    public static function hydrateBase(mixed $result, array $arr)
+    {
+        return $result;
+    }
+}

--- a/src/Models/MerchandisingRule.php
+++ b/src/Models/MerchandisingRule.php
@@ -106,7 +106,7 @@ abstract class MerchandisingRule implements JsonSerializable
         }
         if (array_key_exists("schedule", $arr))
         {
-            $result->schedule = ISchedule::hydrate($arr["schedule"]);
+            $result->schedule = Internal\IScheduleHydrator::hydrate($arr["schedule"]);
         }
         if (array_key_exists("status", $arr))
         {

--- a/src/Models/ProductCategoryInterestTriggerResult.php
+++ b/src/Models/ProductCategoryInterestTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class ProductCategoryInterestTriggerResult
+class ProductCategoryInterestTriggerResult implements ITriggerResult
 {
     public UserResultDetails $user;
     public array $categories;

--- a/src/Models/ProductChangeTriggerResult.php
+++ b/src/Models/ProductChangeTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class ProductChangeTriggerResult extends ProductChangeTriggerResultProductChangeResultDetailsEntityChangeTriggerResult
+class ProductChangeTriggerResult extends ProductChangeTriggerResultProductChangeResultDetailsEntityChangeTriggerResult implements ITriggerResult
 {
     public string $typeDefinition = "Relewise.Client.Responses.Triggers.Results.ProductChangeTriggerResult, Relewise.Client";
     public static function create(UserResultDetails $user, ProductChangeTriggerResultProductChangeResultDetails ... $entitiesWithChanges) : ProductChangeTriggerResult

--- a/src/Models/ProductChangeTriggerResultProductChangeResultDetailsEntityChangeTriggerResult.php
+++ b/src/Models/ProductChangeTriggerResultProductChangeResultDetailsEntityChangeTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-abstract class ProductChangeTriggerResultProductChangeResultDetailsEntityChangeTriggerResult extends EntityChangeTriggerResult
+abstract class ProductChangeTriggerResultProductChangeResultDetailsEntityChangeTriggerResult extends EntityChangeTriggerResult implements ITriggerResult
 {
     public string $typeDefinition = "";
     public array $entitiesWithChanges;

--- a/src/Models/ProductChangeTriggerResultProductChangeTriggerResultSettingsProductPropertySelectorEntityChangeTriggerConfiguration.php
+++ b/src/Models/ProductChangeTriggerResultProductChangeTriggerResultSettingsProductPropertySelectorEntityChangeTriggerConfiguration.php
@@ -46,7 +46,7 @@ abstract class ProductChangeTriggerResultProductChangeTriggerResultSettingsProdu
         }
         if (array_key_exists("change", $arr))
         {
-            $result->change = IChange::hydrate($arr["change"]);
+            $result->change = Internal\IChangeHydrator::hydrate($arr["change"]);
         }
         if (array_key_exists("resultSettings", $arr))
         {

--- a/src/Models/ProductInterestTriggerResult.php
+++ b/src/Models/ProductInterestTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class ProductInterestTriggerResult
+class ProductInterestTriggerResult implements ITriggerResult
 {
     public UserResultDetails $user;
     public array $products;

--- a/src/Models/ScheduledPeriod.php
+++ b/src/Models/ScheduledPeriod.php
@@ -5,7 +5,7 @@ namespace Relewise\Models;
 use DateTime;
 use JsonSerializable;
 
-class ScheduledPeriod implements JsonSerializable
+class ScheduledPeriod implements ISchedule, JsonSerializable
 {
     public ?DateTime $fromUtc;
     public ?DateTime $toUtc;

--- a/src/Models/TriggerResultResponse.php
+++ b/src/Models/TriggerResultResponse.php
@@ -18,7 +18,7 @@ class TriggerResultResponse extends TimedResponse
         $result = TimedResponse::hydrateBase(new TriggerResultResponse(), $arr);
         if (array_key_exists("result", $arr))
         {
-            $result->result = ITriggerResult::hydrate($arr["result"]);
+            $result->result = Internal\ITriggerResultHydrator::hydrate($arr["result"]);
         }
         return $result;
     }

--- a/src/Models/UserActivityTriggerResult.php
+++ b/src/Models/UserActivityTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class UserActivityTriggerResult
+class UserActivityTriggerResult implements ITriggerResult
 {
     public UserResultDetails $user;
     

--- a/src/Models/VariantChangeTriggerResult.php
+++ b/src/Models/VariantChangeTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-class VariantChangeTriggerResult extends VariantChangeTriggerResultVariantChangeResultDetailsEntityChangeTriggerResult
+class VariantChangeTriggerResult extends VariantChangeTriggerResultVariantChangeResultDetailsEntityChangeTriggerResult implements ITriggerResult
 {
     public string $typeDefinition = "Relewise.Client.Responses.Triggers.Results.VariantChangeTriggerResult, Relewise.Client";
     public static function create(UserResultDetails $user, VariantChangeTriggerResultVariantChangeResultDetails ... $entitiesWithChanges) : VariantChangeTriggerResult

--- a/src/Models/VariantChangeTriggerResultVariantChangeResultDetailsEntityChangeTriggerResult.php
+++ b/src/Models/VariantChangeTriggerResultVariantChangeResultDetailsEntityChangeTriggerResult.php
@@ -2,7 +2,7 @@
 
 namespace Relewise\Models;
 
-abstract class VariantChangeTriggerResultVariantChangeResultDetailsEntityChangeTriggerResult extends EntityChangeTriggerResult
+abstract class VariantChangeTriggerResultVariantChangeResultDetailsEntityChangeTriggerResult extends EntityChangeTriggerResult implements ITriggerResult
 {
     public string $typeDefinition = "";
     public array $entitiesWithChanges;

--- a/src/Models/VariantChangeTriggerResultVariantChangeTriggerResultSettingsVariantPropertySelectorEntityChangeTriggerConfiguration.php
+++ b/src/Models/VariantChangeTriggerResultVariantChangeTriggerResultSettingsVariantPropertySelectorEntityChangeTriggerConfiguration.php
@@ -46,7 +46,7 @@ abstract class VariantChangeTriggerResultVariantChangeTriggerResultSettingsVaria
         }
         if (array_key_exists("change", $arr))
         {
-            $result->change = IChange::hydrate($arr["change"]);
+            $result->change = Internal\IChangeHydrator::hydrate($arr["change"]);
         }
         if (array_key_exists("resultSettings", $arr))
         {

--- a/tests/php/unit/HydrationTests.php
+++ b/tests/php/unit/HydrationTests.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Relewise\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Relewise\Models\Campaign;
+use Relewise\Models\Increase;
+use Relewise\Models\ObservableVariantAttributeSelector;
+use Relewise\Models\ScheduledPeriod;
+use Relewise\Models\VariantChangeTriggerConfiguration;
+
+class HydrationTests extends TestCase
+{
+    public function testCampaignHydratesScheduleAsScheduledPeriod(): void
+    {
+        $campaign = Campaign::hydrate([
+            'schedule' => [
+                '$type' => 'Relewise.Client.DataTypes.Scheduling.ScheduledPeriod, Relewise.Client',
+                'fromUtc' => '2026-01-01T12:00:00+00:00',
+                'toUtc' => '2026-01-02T12:00:00+00:00',
+            ],
+        ]);
+
+        self::assertInstanceOf(ScheduledPeriod::class, $campaign->schedule);
+        self::assertSame('2026-01-01T12:00:00+00:00', $campaign->schedule->fromUtc->format(DATE_ATOM));
+        self::assertSame('2026-01-02T12:00:00+00:00', $campaign->schedule->toUtc->format(DATE_ATOM));
+    }
+
+    public function testVariantChangeTriggerConfigurationHydratesNestedTypes(): void
+    {
+        $configuration = VariantChangeTriggerConfiguration::hydrate([
+            'entityPropertySelector' => [
+                '$type' => 'Relewise.Client.DataTypes.EntityPropertySelectors.ObservableVariantAttributeSelector, Relewise.Client',
+                'attribute' => 'SalesPrice',
+            ],
+            'change' => [
+                '$type' => 'Relewise.Client.DataTypes.Changes.Increase, Relewise.Client',
+            ],
+        ]);
+
+        self::assertInstanceOf(ObservableVariantAttributeSelector::class, $configuration->entityPropertySelector);
+        /** @var ObservableVariantAttributeSelector $entityPropertySelector */
+        $entityPropertySelector = $configuration->entityPropertySelector;
+        self::assertSame('SalesPrice', $entityPropertySelector->attribute->value);
+        self::assertInstanceOf(Increase::class, $configuration->change);
+    }
+}


### PR DESCRIPTION
Trello: https://trello.com/c/Cp6YajBx/20565-update-php-and-java-sdk-to-support-interfaces

Changes generation for interfaces from abstract classes to interfaces and adds "hydrator" classes to contain the static "hydrate" methods. Concrete classes now implement the interfaces, making it possible to use them in the model.