### PR TITLE
[codex] Support dispatched API generation

### DIFF
--- a/.github/workflows/generate-api-version.yml
+++ b/.github/workflows/generate-api-version.yml
@@ -1,4 +1,5 @@
 name: Generate API Version
+run-name: Generate API Version - ${{ inputs['dispatch-id'] || github.run_id }}
 
 on:
   workflow_call:
@@ -7,12 +8,22 @@ on:
         description: Trello card URL
         required: true
         type: string
+      dispatch-id:
+        description: Unique id used by callers to find this workflow run
+        required: false
+        type: string
+        default: ''
   workflow_dispatch:
     inputs:
       trello-card-url:
         description: Trello card URL
         required: true
         type: string
+      dispatch-id:
+        description: Unique id used by callers to find this workflow run
+        required: false
+        type: string
+        default: ''
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Add an optional `dispatch-id` input to the API generation workflow.
- Use the dispatch id in `run-name` so callers can reliably find and watch the exact workflow run they triggered.

## Validation
- Parsed edited workflow YAML files with Ruby `YAML.load_file`.
- Ran `git diff --check`; only existing line-ending normalization warnings were reported.
