### PR TITLE
ci: skip integration tests for Dependabot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,24 @@ jobs:
       - name: Generate PHP classes
         run: ./generate.sh
 
-      - name: PHPUnit Tests
+      - name: PHPUnit Unit Tests
+        if: ${{ github.actor == 'dependabot[bot]' }}
         uses: php-actions/phpunit@v3
         with:
           bootstrap: vendor/autoload.php
           configuration: tests/phpunit.xml
           test_suffix: .php
           testsuite: Unit
+          version: 10.0.19
+          php_extensions: "xdebug"
+
+      - name: PHPUnit Tests
+        if: ${{ github.actor != 'dependabot[bot]' }}
+        uses: php-actions/phpunit@v3
+        with:
+          bootstrap: vendor/autoload.php
+          configuration: tests/phpunit.xml
+          test_suffix: .php
           version: 10.0.19
           php_extensions: "xdebug"
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: PHPUnit Unit Tests
         if: ${{ github.actor == 'dependabot[bot]' }}
-        uses: php-actions/phpunit@v3
+        uses: php-actions/phpunit@v4
         with:
           bootstrap: vendor/autoload.php
           configuration: tests/phpunit.xml
@@ -33,7 +33,7 @@ jobs:
 
       - name: PHPUnit Tests
         if: ${{ github.actor != 'dependabot[bot]' }}
-        uses: php-actions/phpunit@v3
+        uses: php-actions/phpunit@v4
         with:
           bootstrap: vendor/autoload.php
           configuration: tests/phpunit.xml

--- a/.github/workflows/generate-api-version.yml
+++ b/.github/workflows/generate-api-version.yml
@@ -139,7 +139,7 @@ jobs:
           DATASET_ID: ${{ secrets.INTEGRATIONTESTS_DATASET_ID }}
           API_KEY: ${{ secrets.INTEGRATIONTESTS_API_KEY }}
           XDEBUG_MODE: coverage
-        run: vendor/bin/phpunit --configuration tests/phpunit.xml --testsuite Unit
+        run: vendor/bin/phpunit --configuration tests/phpunit.xml
 
       - name: Check generated changes
         id: changes
@@ -185,7 +185,7 @@ jobs:
             '- pwsh ./generate.ps1'
             '- API wake-up request with integration dataset credentials'
             '- sleep 60'
-            '- vendor/bin/phpunit --configuration tests/phpunit.xml --testsuite Unit'
+            '- vendor/bin/phpunit --configuration tests/phpunit.xml'
           ) | Set-Content -Path $bodyPath
 
           gh pr create `

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
         run: ./generate.sh
 
       - name: PHPUnit Tests
-        uses: php-actions/phpunit@v3
+        uses: php-actions/phpunit@v4
         with:
           bootstrap: vendor/autoload.php
           configuration: tests/phpunit.xml

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,7 +27,6 @@ jobs:
           bootstrap: vendor/autoload.php
           configuration: tests/phpunit.xml
           test_suffix: .php
-          testsuite: Unit
           version: 9.5.28
         env:
           DATASET_ID: ${{secrets.INTEGRATIONTESTS_DATASET_ID}}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,7 +64,7 @@ Generate SDK code:
 Run all tests configured by CI:
 
 ```powershell
-vendor/bin/phpunit --configuration tests/phpunit.xml --testsuite Unit
+vendor/bin/phpunit --configuration tests/phpunit.xml
 ```
 
 Run unit-only folder (optional fast loop):
@@ -107,6 +107,6 @@ Each PR should include:
 
 ## Known Pitfalls
 - Manual edits to generated code will drift from generator output.
-- `tests/phpunit.xml` points at `tests/php`, so default suite includes both unit and integration folders.
+- The `Integration` PHPUnit suite requires `DATASET_ID` and `API_KEY`; CI skips it for Dependabot-triggered builds.
 - Tests depending on `DATASET_ID`/`API_KEY` fail fast when env is missing.
 - Keep runtime assumptions aligned with `composer.json` (`php: ^8.1`).

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -7,7 +7,10 @@
 	</coverage>
 	<testsuites>
 		<testsuite name="Unit">
-			<directory suffix=".php">./php/</directory>
+			<directory suffix=".php">./php/unit</directory>
+		</testsuite>
+		<testsuite name="Integration">
+			<directory suffix=".php">./php/integration</directory>
 		</testsuite>
 	</testsuites>
 </phpunit>


### PR DESCRIPTION
https://trello.com/c/sSSMPgaY/21180-skip-integration-tests-in-dependabot-builds-for-the-php-sdk

## Summary

- Split the PHPUnit configuration into explicit `Unit` and `Integration` suites.
- Run only the unit suite for Dependabot-triggered builds.
- Continue running the full suite for human-authored branches, main, publishing, and generated SDK updates.
- Upgrade `php-actions/phpunit` from v3 to v4.

## Superseded Dependabot PR

This PR includes the change from #71, which was closed without merging.

The PHPUnit v4 Dependabot branch appeared to fail because the existing `Unit` suite also contained integration tests. Those tests require `DATASET_ID` and `API_KEY`, but the repository's integration credentials are intentionally unavailable to Dependabot-triggered workflows.

The v4 upgrade was folded into this human-authored PR so the upgraded action can be validated by the normal CI path, including integration tests with the existing repository secrets. This also avoids first merging the CI fix with v3 and then resolving overlapping workflow changes when applying #71.

## Security rationale

The integration credentials are a dataset ID and Master API key for real customer datasets. They are not made available to Dependabot. Dependabot builds still compile the SDK and run all tests that do not require those credentials.

## Validation

- Local unit suite: 30 tests, 90 assertions passed.
- `git diff --check` passed.
- No generated SDK code was changed.